### PR TITLE
Set up backend to always use dev cors policy

### DIFF
--- a/backend/src/WebApi/Extensions/ConfigurationExtensions.cs
+++ b/backend/src/WebApi/Extensions/ConfigurationExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace PartyKlinest.WebApi.Extensions
+{
+    public static class ConfigurationExtensions
+    {
+        public static string[] GetAllowedOrigins(this ConfigurationManager configuration)
+        {
+            return configuration.GetSection("AllowedOrigins").Get<string[]>();
+        }
+    }
+}

--- a/backend/src/WebApi/Program.cs
+++ b/backend/src/WebApi/Program.cs
@@ -1,4 +1,5 @@
 using PartyKlinest.Infrastructure;
+using PartyKlinest.WebApi.Extensions;
 using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -6,25 +7,26 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 const string CORS_POLICY_DEV = "CorsPolicyDev";
 const string CORS_POLICY_PROD = "CorsPolicyProd";
-string[] frontend_urls = new string[] { "" }; // TODO
+string[] allowedOrigins = builder.Configuration.GetAllowedOrigins();
 
 builder.Services.AddCors(options =>
 {
     options.AddPolicy(CORS_POLICY_DEV,
-        builder =>
+        corsBuilder =>
         {
-            builder.AllowAnyOrigin(); // unsafe, okay for testing
-            builder.AllowAnyHeader();
-            builder.AllowAnyMethod();
+            corsBuilder.AllowAnyOrigin(); // unsafe, okay for testing
+            corsBuilder.AllowAnyHeader();
+            corsBuilder.AllowAnyMethod();
         });
     options.AddPolicy(CORS_POLICY_PROD,
-        builder =>
+        corsBuilder =>
         {
-            builder.WithOrigins(frontend_urls);
-            builder.AllowAnyHeader();
-            builder.AllowAnyMethod();
+            corsBuilder.WithOrigins(allowedOrigins);
+            corsBuilder.AllowAnyHeader();
+            corsBuilder.AllowAnyMethod();
         });
 });
+
 
 Dependencies.ConfigureServices(builder.Configuration, builder.Services);
 
@@ -51,7 +53,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-if (true) // app.Environment.IsDevelopment()
+if (app.Environment.IsDevelopment())
 {
     app.UseCors(CORS_POLICY_DEV);
 }

--- a/backend/src/WebApi/Program.cs
+++ b/backend/src/WebApi/Program.cs
@@ -51,7 +51,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-if (app.Environment.IsDevelopment())
+if (true) // app.Environment.IsDevelopment()
 {
     app.UseCors(CORS_POLICY_DEV);
 }

--- a/backend/src/WebApi/appsettings.Development.json
+++ b/backend/src/WebApi/appsettings.Development.json
@@ -7,5 +7,8 @@
   },
   "ConnectionStrings": {
     "PartyKlinerDbContext": "$CONNECTION_STRING"
-  }
+  },
+  "AllowedOrigins": [
+    "http://localhost:3000"
+  ]
 }

--- a/backend/src/WebApi/appsettings.json
+++ b/backend/src/WebApi/appsettings.json
@@ -18,5 +18,8 @@
   "ConnectionStrings": {
     "PartyKlinerDbContext": "$CONNECTION_STRING"
   },
+  "AllowedOrigins": [
+    "http://localhost:3000"
+  ],
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
It is required during testing, since we don't want to provide a list of IPs for our testing machines.