### PR TITLE
Feature/orders endpoints backend

### DIFF
--- a/backend/src/ApplicationCore/Services/OrderFacade.cs
+++ b/backend/src/ApplicationCore/Services/OrderFacade.cs
@@ -1,6 +1,7 @@
 ﻿using PartyKlinest.ApplicationCore.Entities;
 using PartyKlinest.ApplicationCore.Entities.Orders;
 using PartyKlinest.ApplicationCore.Entities.Orders.Opinions;
+using PartyKlinest.ApplicationCore.Entities.Users;
 using PartyKlinest.ApplicationCore.Exceptions;
 using PartyKlinest.ApplicationCore.Interfaces;
 using System;
@@ -11,12 +12,15 @@ namespace PartyKlinest.ApplicationCore.Services
 {
     public class OrderFacade
     {
-        public OrderFacade(IRepository<Order> orderRepository)
+        public OrderFacade(IRepository<Order> orderRepository, IRepository<Client> clientRepository)
         {
             _orderRepository = orderRepository;
+            _clientRepository = clientRepository;
         }
 
         private readonly IRepository<Order> _orderRepository;
+        private readonly IRepository<Client> _clientRepository;
+
         private const OrderStatus closedOrder = OrderStatus.Closed;
 
         public async Task<Order> GetOrderAsync(long orderId)
@@ -45,6 +49,15 @@ namespace PartyKlinest.ApplicationCore.Services
 
         public async Task<Order> AddOrderAsync(Order order)
         {
+            var oid = order.ClientId;
+
+            bool clientExists = await _clientRepository.GetByIdAsync(oid) != null;
+            if (!clientExists)
+            {
+                var client = new Client(oid);
+                await _clientRepository.AddAsync(client);
+            }
+
             return await _orderRepository.AddAsync(order);
         }
 

--- a/backend/src/ApplicationCore/Services/OrderFacade.cs
+++ b/backend/src/ApplicationCore/Services/OrderFacade.cs
@@ -90,6 +90,12 @@ namespace PartyKlinest.ApplicationCore.Services
             return await _orderRepository.ListAsync(spec);
         }
 
+        public async Task<List<Order>> ListCreatedOrdersByAsync(string clientId)
+        {
+            var spec = new Specifications.OrdersCreatedBySpecification(clientId);
+            return await _orderRepository.ListAsync(spec);
+        }
+
         public async Task ModifyOrderAsync(long orderId,
             string newClientId, string? newCleanerId,
             OrderStatus newOrderStatus, decimal newMaxPrice,

--- a/backend/src/ApplicationCore/Specifications/OrdersCreatedBySpecification.cs
+++ b/backend/src/ApplicationCore/Specifications/OrdersCreatedBySpecification.cs
@@ -1,0 +1,13 @@
+﻿using Ardalis.Specification;
+using PartyKlinest.ApplicationCore.Entities.Orders;
+
+namespace PartyKlinest.ApplicationCore.Specifications
+{
+    public class OrdersCreatedBySpecification : Specification<Order>
+    {
+        public OrdersCreatedBySpecification(string clientId)
+        {
+            Query.Where(x => x.ClientId == clientId);
+        }
+    }
+}

--- a/backend/src/WebApi/Controllers/CommissionController.cs
+++ b/backend/src/WebApi/Controllers/CommissionController.cs
@@ -22,6 +22,7 @@ namespace PartyKlinest.WebApi.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [Authorize(Policy = "AdminOnly")]
         public async Task<SetCommissionDTO> GetCommissionAsync()
         {
             decimal commissionValue = await _commissionService.GetCommissionAsync();

--- a/backend/src/WebApi/Controllers/OrdersController.cs
+++ b/backend/src/WebApi/Controllers/OrdersController.cs
@@ -150,8 +150,6 @@ namespace PartyKlinest.WebApi.Controllers
 
             try
             {
-                // TODO:
-                //await _clientFacade.AddClientAsync(User.GetOid());
                 await _orderFacade.AddOrderAsync(orderToBeCreated);
             }
             catch (Exception e)

--- a/backend/src/WebApi/Controllers/OrdersController.cs
+++ b/backend/src/WebApi/Controllers/OrdersController.cs
@@ -43,35 +43,37 @@ namespace PartyKlinest.WebApi.Controllers
         }
 
         /// <summary>
-        /// Get orders with assigned cleaners.
+        /// Get orders with assigned for cleaner calling this endpoint.
         /// </summary>
-        /// <returns>Orders with cleaners assigned.</returns>
+        /// <returns>Orders assigned to cleaner.</returns>
         [HttpGet("Cleaner")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        [Authorize]
+        [Authorize(Policy = "CleanerOnly")]
         public async Task<List<Order>> GetAssignedOrdersAsync()
         {
-            _logger.LogInformation("Getting assigned orders");
+            var cleanerId = User.GetOid();
+            _logger.LogInformation("Getting assigned orders for cleaner {cleanerId}", cleanerId);
 
-            return await _orderFacade.ListAssignedOrdersAsync();
+            return await _orderFacade.ListAssignedOrdersToAsync(cleanerId);
         }
 
         /// <summary>
-        /// Get created orders.
+        /// Get orders created by client calling this endpoint.
         /// </summary>
-        /// <returns>Orders which await for assignment.</returns>
+        /// <returns>Orders created by client calling this endpoint</returns>
         [HttpGet("Client")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        [Authorize]
+        [Authorize(Policy = "ClientOnly")]
         public async Task<List<Order>> GetCreatedOrdersAsync()
         {
-            _logger.LogInformation("Getting client orders");
+            var clientId = User.GetOid();
+            _logger.LogInformation("Getting orders for client {clientId}", clientId);
 
-            return await _orderFacade.ListCreatedOrdersAsync();
+            return await _orderFacade.ListCreatedOrdersByAsync(clientId);
         }
 
         /// <summary>
@@ -186,6 +188,12 @@ namespace PartyKlinest.WebApi.Controllers
             }
         }
 
+        /// <summary>
+        /// Modify order.
+        /// </summary>
+        /// <param name="orderId"></param>
+        /// <param name="order"></param>
+        /// <returns></returns>
         [HttpPost("{orderId}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -214,6 +222,11 @@ namespace PartyKlinest.WebApi.Controllers
             return Ok();
         }
 
+        /// <summary>
+        /// Delete order from database.
+        /// </summary>
+        /// <param name="orderId"></param>
+        /// <returns></returns>
         [HttpDelete(template: "{orderId}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -233,6 +246,11 @@ namespace PartyKlinest.WebApi.Controllers
             }
         }
 
+        /// <summary>
+        /// Get list of cleaners that match the criteria for the order.
+        /// </summary>
+        /// <param name="orderId"></param>
+        /// <returns></returns>
         [HttpGet("{orderId}/Matching")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]

--- a/backend/src/WebApi/Controllers/UserController.cs
+++ b/backend/src/WebApi/Controllers/UserController.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using PartyKlinest.WebApi.Models;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 
 namespace PartyKlinest.WebApi.Controllers
 {
@@ -15,22 +15,6 @@ namespace PartyKlinest.WebApi.Controllers
         }
 
         /// <summary>
-        /// Rate client/cleaner by opposite side (in connection to execution of an order)
-        /// </summary>
-        /// <param name="id"></param>
-        /// <param name="addRating"></param>
-        /// <returns></returns>
-        [HttpPost("{id}/Rate")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public IActionResult Rate(int id, [FromBody] AddRatingDTO addRating)
-        {
-            return Ok();
-        }
-
-        /// <summary>
         /// Ban client/cleaner.
         /// </summary>
         /// <param name="id"></param>
@@ -39,6 +23,7 @@ namespace PartyKlinest.WebApi.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [Authorize(Policy = "AdminOnly")]
         public IActionResult Ban(int id)
         {
             return Ok();

--- a/backend/src/WebApi/Extensions/UsersExtensions.cs
+++ b/backend/src/WebApi/Extensions/UsersExtensions.cs
@@ -26,7 +26,7 @@ namespace PartyKlinest.WebApi.Extensions
                     _ => UserType.Unknown
                 };
             }
-            catch (ArgumentNullException _)
+            catch (ArgumentNullException)
             {
                 return UserType.Unknown;
             }

--- a/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/AcceptRejectOrder.cs
+++ b/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/AcceptRejectOrder.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using PartyKlinest.ApplicationCore.Entities.Orders;
+using PartyKlinest.ApplicationCore.Entities.Users;
 using PartyKlinest.ApplicationCore.Entities.Users.Cleaners;
 using PartyKlinest.ApplicationCore.Exceptions;
 using PartyKlinest.ApplicationCore.Interfaces;
@@ -14,6 +15,7 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
     {
         private readonly Mock<IRepository<Order>> _mockOrderRepo = new();
         private readonly Mock<IRepository<Cleaner>> _mockCleanerRepo = new();
+        private readonly Mock<IRepository<Client>> _mockClientRepo = new();
         private readonly Mock<IClientService> _mockClientService = new();
 
         [Theory(DisplayName = "Accept Order")]
@@ -153,7 +155,7 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
                 .Setup(x => x.GetByIdAsync(It.IsAny<long>(), default))
                 .ReturnsAsync(expected);
 
-            OrderFacade orderFacade = new(_mockOrderRepo.Object);
+            OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
             return new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
         }
     }

--- a/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/CheckCleanersPriviliges.cs
+++ b/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/CheckCleanersPriviliges.cs
@@ -1,6 +1,7 @@
 ﻿using Moq;
 using PartyKlinest.ApplicationCore.Entities.Orders;
 using PartyKlinest.ApplicationCore.Entities.Orders.Opinions;
+using PartyKlinest.ApplicationCore.Entities.Users;
 using PartyKlinest.ApplicationCore.Entities.Users.Cleaners;
 using PartyKlinest.ApplicationCore.Exceptions;
 using PartyKlinest.ApplicationCore.Interfaces;
@@ -15,6 +16,7 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
     {
         private readonly Mock<IRepository<Order>> _mockOrderRepo = new();
         private readonly Mock<IRepository<Cleaner>> _mockCleanerRepo = new();
+        private readonly Mock<IRepository<Client>> _mockClientRepo = new();
         private readonly Mock<IClientService> _mockClientService = new();
 
         [Fact]
@@ -69,7 +71,7 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
                 .Setup(x => x.GetByIdAsync(It.IsAny<long>(), default))
                 .ReturnsAsync(expected);
 
-            OrderFacade orderFacade = new(_mockOrderRepo.Object);
+            OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
             return new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
         }
     }

--- a/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/ConfirmOrderCompleted.cs
+++ b/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/ConfirmOrderCompleted.cs
@@ -1,6 +1,7 @@
 ﻿using Moq;
 using PartyKlinest.ApplicationCore.Entities.Orders;
 using PartyKlinest.ApplicationCore.Entities.Orders.Opinions;
+using PartyKlinest.ApplicationCore.Entities.Users;
 using PartyKlinest.ApplicationCore.Entities.Users.Cleaners;
 using PartyKlinest.ApplicationCore.Exceptions;
 using PartyKlinest.ApplicationCore.Interfaces;
@@ -15,6 +16,7 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
     {
         private readonly Mock<IRepository<Order>> _mockOrderRepo = new();
         private readonly Mock<IRepository<Cleaner>> _mockCleanerRepo = new();
+        private readonly Mock<IRepository<Client>> _mockClientRepo = new();
         private readonly Mock<IClientService> _mockClientService = new();
 
         [Fact]
@@ -27,7 +29,7 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
             _mockCleanerRepo
                 .Setup(x => x.GetByIdAsync(It.IsAny<string>(), default))
                 .ReturnsAsync(returnedCleaner);
-            OrderFacade orderFacade = new(_mockOrderRepo.Object);
+            OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
             var cleanerFacade = new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
 
             // Act & Assert
@@ -101,7 +103,8 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
                 .Setup(x => x.GetByIdAsync(It.IsAny<long>(), default))
                 .ReturnsAsync(expected);
 
-            OrderFacade orderFacade = new(_mockOrderRepo.Object);
+            OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
+
             return new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
         }
     }

--- a/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/GetAssignedOrders.cs
+++ b/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/GetAssignedOrders.cs
@@ -1,6 +1,7 @@
 ﻿using Ardalis.Specification;
 using Moq;
 using PartyKlinest.ApplicationCore.Entities.Orders;
+using PartyKlinest.ApplicationCore.Entities.Users;
 using PartyKlinest.ApplicationCore.Entities.Users.Cleaners;
 using PartyKlinest.ApplicationCore.Exceptions;
 using PartyKlinest.ApplicationCore.Interfaces;
@@ -16,6 +17,7 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
     {
         private readonly Mock<IRepository<Order>> _mockOrderRepo = new();
         private readonly Mock<IRepository<Cleaner>> _mockCleanerRepo = new();
+        private readonly Mock<IRepository<Client>> _mockClientRepo = new();
         private readonly Mock<IClientService> _mockClientService = new();
 
         [Fact]
@@ -26,7 +28,7 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
             _mockCleanerRepo
                 .Setup(x => x.GetByIdAsync(It.IsAny<string>(), default))
                 .ReturnsAsync(returnedCleaner);
-            OrderFacade orderFacade = new(_mockOrderRepo.Object);
+            OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
             var cleanerFacade = new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
 
             // Act & Assert
@@ -52,7 +54,7 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
                 .ReturnsAsync(expected);
 
             // Act
-            OrderFacade orderFacade = new(_mockOrderRepo.Object);
+            OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
             var cleanerFacade = new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
 
             var results = await cleanerFacade.GetAssignedOrdersAsync(cleanerId);

--- a/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/GetCleanerInfo.cs
+++ b/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/GetCleanerInfo.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using PartyKlinest.ApplicationCore.Entities.Orders;
+using PartyKlinest.ApplicationCore.Entities.Users;
 using PartyKlinest.ApplicationCore.Entities.Users.Cleaners;
 using PartyKlinest.ApplicationCore.Exceptions;
 using PartyKlinest.ApplicationCore.Interfaces;
@@ -14,6 +15,7 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
     {
         private readonly Mock<IRepository<Order>> _mockOrderRepo = new();
         private readonly Mock<IRepository<Cleaner>> _mockCleanerRepo = new();
+        private readonly Mock<IRepository<Client>> _mockClientRepo = new();
         private readonly Mock<IClientService> _mockClientService = new();
 
         [Fact]
@@ -24,7 +26,7 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
             _mockCleanerRepo
                 .Setup(x => x.GetByIdAsync(It.IsAny<string>(), default))
                 .ReturnsAsync(returnedCleaner);
-            OrderFacade orderFacade = new(_mockOrderRepo.Object);
+            OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
             var cleanerFacade = new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
 
             // Act & Assert
@@ -41,7 +43,7 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
             _mockCleanerRepo
                 .Setup(x => x.GetByIdAsync(It.IsAny<string>(), default))
                 .ReturnsAsync(expectedCleaner);
-            OrderFacade orderFacade = new(_mockOrderRepo.Object);
+            OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
             var cleanerFacade = new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
 
             // Act

--- a/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/ListCleanersMatchingOrder.cs
+++ b/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/ListCleanersMatchingOrder.cs
@@ -1,12 +1,12 @@
-using System;
-using System.Threading.Tasks;
 using Moq;
 using PartyKlinest.ApplicationCore.Entities.Orders;
+using PartyKlinest.ApplicationCore.Entities.Users;
 using PartyKlinest.ApplicationCore.Entities.Users.Cleaners;
 using PartyKlinest.ApplicationCore.Exceptions;
 using PartyKlinest.ApplicationCore.Interfaces;
 using PartyKlinest.ApplicationCore.Services;
 using PartyKlinest.ApplicationCore.Specifications;
+using System.Threading.Tasks;
 using UnitTests.Factories;
 using Xunit;
 
@@ -16,19 +16,20 @@ public class ListCleanersMatchingOrder
 {
     private readonly Mock<IRepository<Order>> _mockOrderRepo = new();
     private readonly Mock<IRepository<Cleaner>> _mockCleanerRepo = new();
+    private readonly Mock<IRepository<Client>> _mockClientRepo = new();
     private readonly Mock<IClientService> _mockClientService = new();
     private readonly OrderBuilder _orderBuilder = new();
-    
+
     [Fact]
     public async Task ThrowsOrderNotFoundExceptionWhenThereIsNoOrderWithGivenId()
     {
         Order? returnedOrder = null;
-        
+
         // Arrange
         _mockOrderRepo
             .Setup(x => x.GetByIdAsync(It.IsAny<long>(), default))
             .ReturnsAsync(returnedOrder);
-        OrderFacade orderFacade = new(_mockOrderRepo.Object);
+        OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
         var cleanerFacade = new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
 
         // Act & Assert
@@ -41,39 +42,39 @@ public class ListCleanersMatchingOrder
     {
         _orderBuilder.WithDefaultValues();
         var order = _orderBuilder.Build();
-        
+
         // Arrange
         _mockOrderRepo
             .Setup(x => x.GetByIdAsync(It.IsAny<long>(), default))
             .ReturnsAsync(order);
-        
-        OrderFacade orderFacade = new(_mockOrderRepo.Object);
+
+        OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
         var cleanerFacade = new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
-        
+
         // Act 
         await cleanerFacade.ListCleanersMatchingOrderAsync(12);
-        
+
         // Assert
         _mockClientService.Verify(x => x.GetAverageClientRatingAsync(It.IsAny<string>()), Times.Once);
     }
-    
+
     [Fact]
     public async Task UsesCleanerRepoWithMatchingSpecificationToGetCleanersMatchingOrder()
     {
         _orderBuilder.WithDefaultValues();
         var order = _orderBuilder.Build();
-        
+
         // Arrange
         _mockOrderRepo
             .Setup(x => x.GetByIdAsync(It.IsAny<long>(), default))
             .ReturnsAsync(order);
-        
-        OrderFacade orderFacade = new(_mockOrderRepo.Object);
+
+        OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
         var cleanerFacade = new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
-        
+
         // Act 
         await cleanerFacade.ListCleanersMatchingOrderAsync(12);
-        
+
         // Assert
         _mockCleanerRepo.Verify(x => x.ListAsync(It.IsAny<CleanersMatchingOrderSpecification>(),
             default), Times.Once);

--- a/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/UpdateOrderFilter.cs
+++ b/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/UpdateOrderFilter.cs
@@ -1,6 +1,7 @@
 ﻿using Moq;
 using PartyKlinest.ApplicationCore.Entities;
 using PartyKlinest.ApplicationCore.Entities.Orders;
+using PartyKlinest.ApplicationCore.Entities.Users;
 using PartyKlinest.ApplicationCore.Entities.Users.Cleaners;
 using PartyKlinest.ApplicationCore.Exceptions;
 using PartyKlinest.ApplicationCore.Interfaces;
@@ -16,6 +17,8 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
         private readonly Mock<IRepository<Order>> _mockOrderRepo = new();
         private readonly Mock<IRepository<Cleaner>> _mockCleanerRepo = new();
         private readonly Mock<IClientService> _mockClientService = new();
+        private readonly Mock<IRepository<Client>> _mockClientRepo = new();
+
 
         [Theory]
         [InlineData(CleanerStatus.Active, CleanerStatus.Registered)]
@@ -38,7 +41,8 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
             _mockCleanerRepo
                 .Setup(x => x.GetByIdAsync(It.IsAny<string>(), default))
                 .ReturnsAsync(localCleaner);
-            OrderFacade orderFacade = new(_mockOrderRepo.Object);
+            OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
+
             var cleanerFacade = new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
 
             // Act & Assert
@@ -66,7 +70,8 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
             _mockCleanerRepo
                 .Setup(x => x.GetByIdAsync(It.IsAny<string>(), default))
                 .ReturnsAsync(localCleaner);
-            OrderFacade orderFacade = new(_mockOrderRepo.Object);
+            OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
+
             var cleanerFacade = new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
 
             // Act
@@ -96,7 +101,8 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
             _mockCleanerRepo
                 .Setup(x => x.GetByIdAsync(It.IsAny<string>(), default))
                 .ReturnsAsync(localCleaner);
-            OrderFacade orderFacade = new(_mockOrderRepo.Object);
+            OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
+
             var cleanerFacade = new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
 
             // Act

--- a/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/UpdateSchedule.cs
+++ b/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/UpdateSchedule.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using PartyKlinest.ApplicationCore.Entities.Orders;
+using PartyKlinest.ApplicationCore.Entities.Users;
 using PartyKlinest.ApplicationCore.Entities.Users.Cleaners;
 using PartyKlinest.ApplicationCore.Interfaces;
 using PartyKlinest.ApplicationCore.Services;
@@ -15,6 +16,7 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
     {
         private readonly Mock<IRepository<Order>> _mockOrderRepo = new();
         private readonly Mock<IRepository<Cleaner>> _mockCleanerRepo = new();
+        private readonly Mock<IRepository<Client>> _mockClientRepo = new();
         private readonly Mock<IClientService> _mockClientService = new();
 
         [Theory(DisplayName = "Make 1 Update: shedule")]
@@ -40,7 +42,7 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
             _mockCleanerRepo
                 .Setup(x => x.GetByIdAsync(It.IsAny<string>(), default))
                 .ReturnsAsync(localCleaner);
-            OrderFacade orderFacade = new(_mockOrderRepo.Object);
+            OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
             var cleanerFacade = new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
 
             // Act

--- a/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/UpdateStatus.cs
+++ b/backend/tests/UnitTests/ApplicationCore/Services/CleanerFacadeTests/UpdateStatus.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using PartyKlinest.ApplicationCore.Entities.Orders;
+using PartyKlinest.ApplicationCore.Entities.Users;
 using PartyKlinest.ApplicationCore.Entities.Users.Cleaners;
 using PartyKlinest.ApplicationCore.Exceptions;
 using PartyKlinest.ApplicationCore.Interfaces;
@@ -14,6 +15,8 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
     {
         private readonly Mock<IRepository<Order>> _mockOrderRepo = new();
         private readonly Mock<IRepository<Cleaner>> _mockCleanerRepo = new();
+        private readonly Mock<IRepository<Client>> _mockClientRepo = new();
+
         private readonly Mock<IClientService> _mockClientService = new();
 
         [Theory(DisplayName = "Cleaner cannot change status from banned to ")]
@@ -35,7 +38,8 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
             _mockCleanerRepo
                 .Setup(x => x.GetByIdAsync(It.IsAny<string>(), default))
                 .ReturnsAsync(localCleaner);
-            OrderFacade orderFacade = new(_mockOrderRepo.Object);
+            OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
+
             var cleanerFacade = new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
 
             // Act & Assert
@@ -62,7 +66,8 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
             _mockCleanerRepo
                 .Setup(x => x.GetByIdAsync(It.IsAny<string>(), default))
                 .ReturnsAsync(localCleaner);
-            OrderFacade orderFacade = new(_mockOrderRepo.Object);
+            OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
+
             var cleanerFacade = new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
 
             // Act & Assert
@@ -87,7 +92,8 @@ namespace UnitTests.ApplicationCore.Services.CleanerFacadeTests
             _mockCleanerRepo
                 .Setup(x => x.GetByIdAsync(It.IsAny<string>(), default))
                 .ReturnsAsync(localCleaner);
-            OrderFacade orderFacade = new(_mockOrderRepo.Object);
+            OrderFacade orderFacade = new(_mockOrderRepo.Object, _mockClientRepo.Object);
+
             var cleanerFacade = new CleanerFacade(_mockCleanerRepo.Object, orderFacade, _mockClientService.Object);
 
             // Act

--- a/backend/tests/UnitTests/ApplicationCore/Services/OrderFacadeTests/AddOrder.cs
+++ b/backend/tests/UnitTests/ApplicationCore/Services/OrderFacadeTests/AddOrder.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using PartyKlinest.ApplicationCore.Entities.Orders;
+using PartyKlinest.ApplicationCore.Entities.Users;
 using PartyKlinest.ApplicationCore.Interfaces;
 using PartyKlinest.ApplicationCore.Services;
 using System.Threading.Tasks;
@@ -11,6 +12,7 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
     public class AddOrder
     {
         private readonly Mock<IRepository<Order>> _mockOrderRepo = new();
+        private readonly Mock<IRepository<Client>> _mockClientRepo = new();
 
         [Fact]
         public async Task AddsOrderToRepo()
@@ -22,12 +24,54 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
                 .Setup(x => x.AddAsync(It.IsAny<Order>(), default))
                 .ReturnsAsync(order);
 
-            var orderFacade = new OrderFacade(_mockOrderRepo.Object);
+            var orderFacade = new OrderFacade(_mockOrderRepo.Object, _mockClientRepo.Object);
 
             await orderFacade.AddOrderAsync(order);
 
             _mockOrderRepo
                 .Verify(x => x.AddAsync(It.Is<Order>(o => o == order), default), Times.Once);
+        }
+
+        [Fact]
+        public async Task AddsClientIfItDoesntExistInDb()
+        {
+            var orderBuilder = new OrderBuilder();
+            Order order = orderBuilder.Build();
+
+            _mockOrderRepo
+                .Setup(x => x.AddAsync(It.IsAny<Order>(), default))
+                .ReturnsAsync(order);
+            _mockClientRepo
+                .Setup(x => x.GetByIdAsync(It.IsAny<string>(), default))
+                .ReturnsAsync((Client?)null);
+
+            var orderFacade = new OrderFacade(_mockOrderRepo.Object, _mockClientRepo.Object);
+
+            await orderFacade.AddOrderAsync(order);
+
+            _mockClientRepo
+                .Verify(x => x.AddAsync(It.Is<Client>(c => c.ClientId == order.ClientId), default), Times.Once);
+        }
+
+        [Fact]
+        public async Task DoesntAddClientIfItExistsInDb()
+        {
+            var orderBuilder = new OrderBuilder();
+            Order order = orderBuilder.Build();
+
+            _mockOrderRepo
+                .Setup(x => x.AddAsync(It.IsAny<Order>(), default))
+                .ReturnsAsync(order);
+            _mockClientRepo
+                .Setup(x => x.GetByIdAsync(It.IsAny<string>(), default))
+                .ReturnsAsync(new Client(order.ClientId));
+
+            var orderFacade = new OrderFacade(_mockOrderRepo.Object, _mockClientRepo.Object);
+
+            await orderFacade.AddOrderAsync(order);
+
+            _mockClientRepo
+                .Verify(x => x.AddAsync(It.IsAny<Client>(), default), Times.Never);
         }
     }
 }

--- a/backend/tests/UnitTests/ApplicationCore/Services/OrderFacadeTests/DeleteOrder.cs
+++ b/backend/tests/UnitTests/ApplicationCore/Services/OrderFacadeTests/DeleteOrder.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using PartyKlinest.ApplicationCore.Entities.Orders;
+using PartyKlinest.ApplicationCore.Entities.Users;
 using PartyKlinest.ApplicationCore.Exceptions;
 using PartyKlinest.ApplicationCore.Interfaces;
 using PartyKlinest.ApplicationCore.Services;
@@ -12,6 +13,7 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
     public class DeleteOrder
     {
         private readonly Mock<IRepository<Order>> _mockOrderRepo = new();
+        private readonly Mock<IRepository<Client>> _mockClientRepo = new();
 
         [Fact]
         public async Task ThrowsOrderNotFoundExceptionWhenThereIsNoOrderWithGivenId()
@@ -24,7 +26,7 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
                 .Setup(x => x.GetByIdAsync(It.IsAny<long>(), default))
                 .ReturnsAsync(returnedOrder);
 
-            var orderFacade = new OrderFacade(_mockOrderRepo.Object);
+            var orderFacade = new OrderFacade(_mockOrderRepo.Object, _mockClientRepo.Object);
 
             await Assert.ThrowsAsync<OrderNotFoundException>(() => orderFacade.DeleteOrderAsync(orderId));
         }
@@ -40,7 +42,7 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
                 .Setup(x => x.GetByIdAsync(It.IsAny<long>(), default))
                 .ReturnsAsync(returnedOrder);
 
-            var orderFacade = new OrderFacade(_mockOrderRepo.Object);
+            var orderFacade = new OrderFacade(_mockOrderRepo.Object, _mockClientRepo.Object);
 
             await orderFacade.DeleteOrderAsync(orderId);
 

--- a/backend/tests/UnitTests/ApplicationCore/Services/OrderFacadeTests/GetOrder.cs
+++ b/backend/tests/UnitTests/ApplicationCore/Services/OrderFacadeTests/GetOrder.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using PartyKlinest.ApplicationCore.Entities.Orders;
+using PartyKlinest.ApplicationCore.Entities.Users;
 using PartyKlinest.ApplicationCore.Exceptions;
 using PartyKlinest.ApplicationCore.Interfaces;
 using PartyKlinest.ApplicationCore.Services;
@@ -12,6 +13,7 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
     public class GetOrder
     {
         private readonly Mock<IRepository<Order>> _mockOrderRepo = new();
+        private readonly Mock<IRepository<Client>> _mockClientRepo = new();
 
         [Fact]
         public async Task ThrowsOrderNotFoundExceptionWhenThereIsNoOrderWithGivenId()
@@ -19,7 +21,7 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
             Order? returnedOrder = null;
             _mockOrderRepo.Setup(x => x.GetByIdAsync(It.IsAny<long>(), default)).ReturnsAsync(returnedOrder);
 
-            var orderFacade = new OrderFacade(_mockOrderRepo.Object);
+            var orderFacade = new OrderFacade(_mockOrderRepo.Object, _mockClientRepo.Object);
 
             await Assert.ThrowsAsync<OrderNotFoundException>(() => orderFacade.GetOrderAsync(1));
         }
@@ -33,7 +35,7 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
 
             _mockOrderRepo.Setup(x => x.GetByIdAsync(It.IsAny<long>(), default)).ReturnsAsync(expected);
 
-            var orderFacade = new OrderFacade(_mockOrderRepo.Object);
+            var orderFacade = new OrderFacade(_mockOrderRepo.Object, _mockClientRepo.Object);
 
             var result = await orderFacade.GetOrderAsync(orderBuilder.TestOrderId);
             Assert.Equal(expected, result);

--- a/backend/tests/UnitTests/ApplicationCore/Services/OrderFacadeTests/ModifyOrder.cs
+++ b/backend/tests/UnitTests/ApplicationCore/Services/OrderFacadeTests/ModifyOrder.cs
@@ -1,6 +1,7 @@
 ﻿using Moq;
 using PartyKlinest.ApplicationCore.Entities;
 using PartyKlinest.ApplicationCore.Entities.Orders;
+using PartyKlinest.ApplicationCore.Entities.Users;
 using PartyKlinest.ApplicationCore.Exceptions;
 using PartyKlinest.ApplicationCore.Interfaces;
 using PartyKlinest.ApplicationCore.Services;
@@ -14,6 +15,7 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
     public class ModifyOrder
     {
         private readonly Mock<IRepository<Order>> _mockOrderRepo = new();
+        private readonly Mock<IRepository<Client>> _mockClientRepo = new();
 
         [Fact]
         public async Task ThrowsOrderNotFoundExceptionWhenThereIsNoOrderWithGivenId()
@@ -21,7 +23,7 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
             Order? returnedOrder = null;
             _mockOrderRepo.Setup(x => x.GetByIdAsync(It.IsAny<long>(), default)).ReturnsAsync(returnedOrder);
 
-            var orderFacade = new OrderFacade(_mockOrderRepo.Object);
+            var orderFacade = new OrderFacade(_mockOrderRepo.Object, _mockClientRepo.Object);
 
             string newCleanerId = "newCleanerId";
             string newClientId = "newCustomerId";
@@ -44,7 +46,7 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
             Order? returnedOrder = new OrderBuilder().Build();
             _mockOrderRepo.Setup(x => x.GetByIdAsync(It.IsAny<long>(), default)).ReturnsAsync(returnedOrder);
 
-            var orderFacade = new OrderFacade(_mockOrderRepo.Object);
+            var orderFacade = new OrderFacade(_mockOrderRepo.Object, _mockClientRepo.Object);
 
             string newCleanerId = "newCleanerId";
             string newClientId = "newCustomerId";
@@ -68,7 +70,7 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
             Order? returnedOrder = new OrderBuilder().Build();
             _mockOrderRepo.Setup(x => x.GetByIdAsync(It.IsAny<long>(), default)).ReturnsAsync(returnedOrder);
 
-            var orderFacade = new OrderFacade(_mockOrderRepo.Object);
+            var orderFacade = new OrderFacade(_mockOrderRepo.Object, _mockClientRepo.Object);
 
             string newCleanerId = "newCleanerId";
             string newClientId = "newCustomerId";

--- a/backend/tests/UnitTests/ApplicationCore/Services/OrderFacadeTests/SubmitOpinionCleaner.cs
+++ b/backend/tests/UnitTests/ApplicationCore/Services/OrderFacadeTests/SubmitOpinionCleaner.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using PartyKlinest.ApplicationCore.Entities.Orders;
+using PartyKlinest.ApplicationCore.Entities.Users;
 using PartyKlinest.ApplicationCore.Exceptions;
 using PartyKlinest.ApplicationCore.Interfaces;
 using PartyKlinest.ApplicationCore.Services;
@@ -11,6 +12,7 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
 {
     public class SubmitOpinionCleaner
     {
+        private readonly Mock<IRepository<Client>> _mockClientRepo = new();
         private readonly Mock<IRepository<Order>> _mockOrderRepo = new();
 
         [Fact]
@@ -23,7 +25,7 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
 
             _mockOrderRepo.Setup(x => x.GetByIdAsync(It.IsAny<long>(), default)).ReturnsAsync(returnedOrder);
 
-            var orderFacade = new OrderFacade(_mockOrderRepo.Object);
+            var orderFacade = new OrderFacade(_mockOrderRepo.Object, _mockClientRepo.Object);
 
             await Assert.ThrowsAsync<OrderNotFoundException>(() => orderFacade.SubmitOpinionCleanerAsync(orderId, opinion));
         }
@@ -43,7 +45,7 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
 
             Assert.Null(order.CleanersOpinion);
 
-            var orderFacade = new OrderFacade(_mockOrderRepo.Object);
+            var orderFacade = new OrderFacade(_mockOrderRepo.Object, _mockClientRepo.Object);
             await orderFacade.SubmitOpinionCleanerAsync(orderId, opinion);
 
             _mockOrderRepo.Verify(x =>

--- a/backend/tests/UnitTests/ApplicationCore/Services/OrderFacadeTests/SubmitOpinionClient.cs
+++ b/backend/tests/UnitTests/ApplicationCore/Services/OrderFacadeTests/SubmitOpinionClient.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using PartyKlinest.ApplicationCore.Entities.Orders;
+using PartyKlinest.ApplicationCore.Entities.Users;
 using PartyKlinest.ApplicationCore.Exceptions;
 using PartyKlinest.ApplicationCore.Interfaces;
 using PartyKlinest.ApplicationCore.Services;
@@ -12,6 +13,7 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
     public class SubmitOpinionClient
     {
         private readonly Mock<IRepository<Order>> _mockOrderRepo = new();
+        private readonly Mock<IRepository<Client>> _mockClientRepo = new();
 
         [Fact]
         public async Task ThrowsOrderNotFoundExceptionWhenThereIsNoOrderWithGivenId()
@@ -23,7 +25,7 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
 
             _mockOrderRepo.Setup(x => x.GetByIdAsync(It.IsAny<long>(), default)).ReturnsAsync(returnedOrder);
 
-            var orderFacade = new OrderFacade(_mockOrderRepo.Object);
+            var orderFacade = new OrderFacade(_mockOrderRepo.Object, _mockClientRepo.Object);
 
             await Assert.ThrowsAsync<OrderNotFoundException>(() => orderFacade.SubmitOpinionClientAsync(orderId, opinion));
         }
@@ -43,7 +45,7 @@ namespace UnitTests.ApplicationCore.Services.OrderFacadeTests
 
             Assert.Null(order.ClientsOpinion);
 
-            var orderFacade = new OrderFacade(_mockOrderRepo.Object);
+            var orderFacade = new OrderFacade(_mockOrderRepo.Object, _mockClientRepo.Object);
             await orderFacade.SubmitOpinionClientAsync(orderId, opinion);
 
             _mockOrderRepo.Verify(x =>

--- a/backend/tests/UnitTests/ApplicationCore/Specifications/OrdersCreatedBySpecificationTest.cs
+++ b/backend/tests/UnitTests/ApplicationCore/Specifications/OrdersCreatedBySpecificationTest.cs
@@ -1,0 +1,47 @@
+﻿using PartyKlinest.ApplicationCore.Entities;
+using PartyKlinest.ApplicationCore.Entities.Orders;
+using PartyKlinest.ApplicationCore.Specifications;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnitTests.Factories;
+using Xunit;
+
+namespace UnitTests.ApplicationCore.Specifications
+{
+    public class OrdersCreatedBySpecificationTest
+    {
+        [Theory]
+        [InlineData("1", 3)]
+        [InlineData("2", 1)]
+        [InlineData("12", 0)]
+        public void MatchesExpectedNumberOfOrders(string clientId, int expectedCount)
+        {
+            var spec = new OrdersCreatedBySpecification(clientId);
+
+            var result = GetTestOrdersCollection()
+                .AsQueryable()
+                .Where(spec.WhereExpressions.FirstOrDefault()!.Filter);
+
+            Assert.Equal(expectedCount, result.Count());
+        }
+
+        public static List<Order> GetTestOrdersCollection()
+        {
+            var addressFactory = new AddressFactory();
+            var address = addressFactory.CreateWithDefaultValues();
+            var orders = new List<Order>()
+            {
+                new Order(12m, 1, MessLevel.Disaster, DateTimeOffset.FromUnixTimeSeconds(1335174932), "1", address),
+                new Order(13m, 2, MessLevel.Low, DateTimeOffset.FromUnixTimeSeconds(1335375932), "2", address),
+                new Order(14m, 3, MessLevel.Huge, DateTimeOffset.FromUnixTimeSeconds(1235175932), "3", address),
+                new Order(15m, 4, MessLevel.Disaster, DateTimeOffset.FromUnixTimeSeconds(1335175432), "1", address),
+                new Order(16m, 5, MessLevel.Moderate, DateTimeOffset.FromUnixTimeSeconds(1335115932), "1", address),
+            };
+
+
+            return orders;
+        }
+
+    }
+}


### PR DESCRIPTION
Działają te endpointy:
![image](https://user-images.githubusercontent.com/62249621/167118148-44629cbb-6a63-4ab6-beb5-f15866363105.png)
Jednocześnie nie można przypisywać w tej chwili cleanerów, gdyż brakuje endpointów związanych z aktualizacją schedule cleaneara który de facto także dodaje go do bazy.

Można testować bezpośrednio w swaggerze, aczkolwiek wymaga to wcześniejszego uzyskania tokenu:
1. odpalamy frontend i logujemy się na jakieś konto np Clienta.
2. w narzędziach deweloperskich przeglądarki wchodzimy w storage i szukamy Session Storage
![image](https://user-images.githubusercontent.com/62249621/167118962-d31a682e-3b9a-4aa0-828e-101aa121cd54.png)
3. szukamy "credentialType":"IdToken" (zaznaczony na zielono)
4. kopiujemy secret
![image](https://user-images.githubusercontent.com/62249621/167119316-4cd3f8f1-167b-46fb-846f-71dd958c775a.png)
5. możemy sprawdzić wartości z tokena wklejając ją tutaj https://jwt.ms/ bez słowa secret i spacji. Cudzysłów może chyba zostać.
6. jeśli jest poprawna to wrzucamy ją do swaggera, klikając w Authorize 
![image](https://user-images.githubusercontent.com/62249621/167120561-db3b1daf-b73d-434c-a99c-5358e18bd56b.png)
7. wklejamy token w formacie "Bearer xxxx" gdzie xxx to wartość tokenu bez cudzysłowu i słowa secret.
![image](https://user-images.githubusercontent.com/62249621/167120991-f2657b76-f25f-4534-b7cf-f1822b65dde8.png)

Następnie jesteśmy zalogowani i mamy dostęp do endpointów dla danego użytkownika.
