### PR TITLE
Fix user extensions

### DIFF
--- a/backend/src/WebApi/Extensions/UsersExtensions.cs
+++ b/backend/src/WebApi/Extensions/UsersExtensions.cs
@@ -47,29 +47,19 @@ namespace PartyKlinest.WebApi.Extensions
             return user.GetUserType() == UserType.Client;
         }
 
-        public static string GetName(this ClaimsPrincipal user)
-        {
-            return user.Claims.Where(c => c.Type == "given_name").First().Value;
-        }
-
-        public static string GetSurname(this ClaimsPrincipal user)
-        {
-            return user.Claims.Where(c => c.Type == "family_name").First().Value;
-        }
-
-        public static string GetEmail(this ClaimsPrincipal user)
-        {
-            return user.Claims.Where(c => c.Type == "email").First().Value;
-        }
-
         public static string GetOid(this ClaimsPrincipal user)
         {
-            return user.Claims.Where(c => c.Type == "oid").First().Value;
+            return user.Claims.Where(c => c.Type == "oid" || c.Type == @"http://schemas.microsoft.com/identity/claims/objectidentifier").First().Value;
         }
 
         public static bool IsBanned(this ClaimsPrincipal user)
         {
-            return user.Claims.Where(c => c.Type == "extension_isBanned").First().Value == "true";
+            var isBannedClaims = user.Claims.Where(c => c.Type == "extension_isBanned" || c.Type == @"http://schemas.microsoft.com/identity/claims/isbanned" || c.Type == "isBanned");
+            if (isBannedClaims.Count() == 1 && isBannedClaims.First().Value == "true")
+            {
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/backend/tests/UnitTests/UnitTests.csproj
+++ b/backend/tests/UnitTests/UnitTests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\ApplicationCore\ApplicationCore.csproj" />
+    <ProjectReference Include="..\..\src\WebApi\WebApi.csproj" />
   </ItemGroup>
 
 </Project>

--- a/backend/tests/UnitTests/WebApi/Extensions/UsersExtensionsTests/GetOid.cs
+++ b/backend/tests/UnitTests/WebApi/Extensions/UsersExtensionsTests/GetOid.cs
@@ -1,0 +1,64 @@
+﻿using PartyKlinest.WebApi.Extensions;
+using System;
+using System.Security.Claims;
+using Xunit;
+
+namespace UnitTests.WebApi.Extensions.UsersExtensionsTests
+{
+    public class GetOid
+    {
+        [Fact]
+        public void GetOid_WhenOidUsesSchema_ReturnsOid()
+        {
+            string oid = "oid";
+
+            // Arrange
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+            {
+                new Claim("http://schemas.microsoft.com/identity/claims/objectidentifier", oid),
+                new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name", "name"),
+                new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname", "surname"),
+            }));
+
+            // Act
+            var result = user.GetOid();
+
+            // Assert
+            Assert.Equal(oid, result);
+        }
+
+        [Fact]
+        public void GetOid_WhenOidUsesOid_ReturnsOid()
+        {
+            string oid = "oid";
+
+            // Arrange
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+            {
+                new Claim("oid", oid),
+                new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name", "name"),
+                new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname", "surname"),
+            }));
+
+            // Act
+            var result = user.GetOid();
+
+            // Assert
+            Assert.Equal(oid, result);
+        }
+
+        [Fact]
+        public void GetOid_WhenOidIsntPresent_ThrowsException()
+        {
+            // Arrange
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+            {
+                new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name", "name"),
+                new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname", "surname"),
+            }));
+
+            // Act & Assert
+            var result = Assert.Throws<InvalidOperationException>(() => user.GetOid());
+        }
+    }
+}

--- a/backend/tests/UnitTests/WebApi/Extensions/UsersExtensionsTests/IsBanned.cs
+++ b/backend/tests/UnitTests/WebApi/Extensions/UsersExtensionsTests/IsBanned.cs
@@ -1,0 +1,46 @@
+﻿using PartyKlinest.WebApi.Extensions;
+using System.Security.Claims;
+using Xunit;
+
+namespace UnitTests.WebApi.Extensions.UsersExtensionsTests
+{
+    public class IsBanned
+    {
+        [Fact]
+        public void IsBanned_GivenUserIsNotBanned_ReturnsFalse()
+        {
+            // Arrange
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+            {
+                new Claim("http://schemas.microsoft.com/identity/claims/objectidentifier", "oid"),
+                new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name", "name"),
+                new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname", "surname"),
+            }));
+
+            // Act
+            var result = user.IsBanned();
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsBanned_GivenUserIsBanned_ReturnsFalse()
+        {
+            // Arrange
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+            {
+                new Claim("http://schemas.microsoft.com/identity/claims/objectidentifier", "oid"),
+                new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name", "name"),
+                new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname", "surname"),
+                new Claim("extension_isBanned", "true"),
+            }));
+
+            // Act
+            var result = user.IsBanned();
+
+            // Assert
+            Assert.True(result);
+        }
+    }
+}


### PR DESCRIPTION
PR naprawia problem z `oid` gdy jest w claimsach zapisane pod kluczem `http://schemas.microsoft.com/identity/claims/objectidentifier`.

Ponadto dodałem testy i usunąłem nie używane metody.